### PR TITLE
Implement permission filters for Asset Request

### DIFF
--- a/sahayog_asset/hooks.py
+++ b/sahayog_asset/hooks.py
@@ -44,6 +44,13 @@ app_license = "MIT"
 # role_home_page = {
 #	"Role": "home_page"
 # }
+permission_query_conditions = {
+    "Asset Request": "sahayog_asset.sahayog_asset.doctype.asset_request.asset_request.get_permission_query_conditions",
+}
+
+has_permission = {
+    "Asset Request": "sahayog_asset.sahayog_asset.doctype.asset_request.asset_request.has_permission",
+}
 
 # Generators
 # ----------

--- a/sahayog_asset/sahayog_asset/doctype/asset_list/asset_list.json
+++ b/sahayog_asset/sahayog_asset/doctype/asset_list/asset_list.json
@@ -90,7 +90,6 @@
    "in_list_view": 1,
    "label": "Store",
    "options": "Pending\nDispatch\nSelf-Purchase",
-   "permlevel": 1,
    "read_only_depends_on": "eval:doc.purchase == \"Pending\" || doc.dispatched_locked==\"True\""
   },
   {
@@ -135,8 +134,7 @@
    "fieldtype": "Select",
    "label": "Mode of Transport",
    "mandatory_depends_on": "eval:doc.dispatched_status == \"Dispatch\"",
-   "options": "\nCourier\nBus\nTrain\nTruck\nCar\nBike\nBy Hand\nBy Vendor",
-   "permlevel": 1
+   "options": "\nCourier\nBus\nTrain\nTruck\nCar\nBike\nBy Hand\nBy Vendor"
   },
   {
    "fieldname": "column_break_hf2no",
@@ -147,8 +145,7 @@
    "fieldname": "transport_remark",
    "fieldtype": "Small Text",
    "label": "Transport Remark",
-   "mandatory_depends_on": "eval:doc.dispatched_status == \"Dispatch\"",
-   "permlevel": 1
+   "mandatory_depends_on": "eval:doc.dispatched_status == \"Dispatch\""
   },
   {
    "fieldname": "approval_level",
@@ -182,8 +179,7 @@
    "fieldname": "dispatched_location",
    "fieldtype": "Small Text",
    "label": "Dispatched Location",
-   "mandatory_depends_on": "eval:doc.dispatched_status == \"Dispatch\" && !frappe.user.has_role('Purchase Department') && doc.status ==\"Pending From Store Manager\"",
-   "permlevel": 1
+   "mandatory_depends_on": "eval:doc.dispatched_status == \"Dispatch\" && !frappe.user.has_role('Purchase Department') && doc.status ==\"Pending From Store Manager\""
   },
   {
    "fieldname": "column_break_p4afy",
@@ -250,12 +246,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-28 12:45:55.273422",
+ "modified": "2025-07-05 15:38:22.216378",
  "modified_by": "Administrator",
  "module": "Sahayog Asset",
  "name": "Asset List",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/sahayog_asset/sahayog_asset/doctype/asset_request/asset_request.js
+++ b/sahayog_asset/sahayog_asset/doctype/asset_request/asset_request.js
@@ -49,6 +49,16 @@ frappe.ui.form.on("Asset List", {
   },
 });
 
+frappe.ui.form.on("Asset List", {
+  asset_add: function (frm, cdt, cdn) {
+    let row = locals[cdt][cdn];
+    if (!row.dispatched_status) {
+      row.dispatched_status = "Pending";
+      frm.refresh_field("asset"); // Refresh the field to reflect the change
+    }
+  },
+});
+
 frappe.ui.form.on("Asset Request", {
   onload: function (frm) {
     $("span.sidebar-toggle-btn").hide();
@@ -2070,73 +2080,66 @@ frappe.ui.form.on("Asset Request", {
         } else if (frm.doc.status == "Received") {
           frm.trigger("Asset_Delivered");
         }
-        if (
-          (frm.doc.status == "Pending" &&
-            frm.doc.stage_7_emp_status == "Pending" &&
-            frm.doc.stage_5_emp_status !== "Pending") ||
-          frm.doc.status == "Pending From Purchase" ||
-          frm.doc.status == "Pending From Store Manager"
-        ) {
-          if (frm.doc.status == "Pending From Store Manager") {
-            console.log("pending from store Manager");
-            frm.set_df_property("asset", "read_only", 0);
-            frm.trigger("dispatch_button");
-          } else if (frm.doc.purchase_status == "Delivered To Store") {
-            frm.trigger("dispatch_button");
-          } else if (frm.doc.status == "Dispatched") {
-            frm.set_df_property("asset", "read_only", 1);
-          } else {
-            frm.set_df_property("asset", "read_only", 1);
-          }
+        if (frm.doc.status == "Pending From Store Manager") {
+          console.log("pending from store Manager");
+          frm.set_df_property("asset", "read_only", 0);
+          frm.trigger("dispatch_button");
+          console.log("dispatch button triggered");
+        } else if (frm.doc.purchase_status == "Delivered To Store") {
+          frm.trigger("dispatch_button");
+        } else if (frm.doc.status == "Dispatched") {
+          frm.set_df_property("asset", "read_only", 1);
+        } else {
+          frm.set_df_property("asset", "read_only", 1);
+        }
 
-          if (
-            frm.doc.status == "Pending" &&
-            frm.doc.stage_7_emp_status !== "Pending From Purchase"
-          ) {
-            // frm.add_custom_button(__("Pending From Purchase"), function () {
-            //   var d = new frappe.ui.Dialog({
-            //     title: __("Pending From Purchase Reason"),
-            //     fields: [
-            //       {
-            //         label: __(
-            //           "Please Give Reason of unavailability for this Asset Request"
-            //         ),
-            //         fieldname: "stage_7_emp_unavailable_reason",
-            //         fieldtype: "Small Text",
-            //         reqd: 1, // Set the unavailability reason field as mandatory
-            //       },
-            //     ],
-            //     primary_action_label: __("Submit"),
-            //     primary_action: function () {
-            //       // Check if the unavailability reason is provided
-            //       if (!d.fields_dict.stage_7_emp_unavailable_reason.get_value()) {
-            //         frappe.msgprint(
-            //           __("Please provide an unavailability reason.")
-            //         );
-            //         return;
-            //       }
-            //       // Generate a random 4-digit number
-            //       var randomOTP = Math.floor(1000 + Math.random() * 9000);
-            //       frm.set_value("stage_7_emp_status", "Pending From Purchase");
-            //       frm.set_value("store_otp", randomOTP); // Set the random number to store_otp
-            //       frm.set_value(
-            //         "stage_7_emp_unavailable_reason",
-            //         d.fields_dict.stage_7_emp_unavailable_reason.get_value()
-            //       );
-            //       d.hide();
-            //       frm.set_value("status", "Pending From Purchase");
-            //       console.log("Pending from Button");
-            //       frm.trigger("share_with_purchase");
-            //       cur_frm.save();
-            //     },
-            //     secondary_action_label: __("Cancel"),
-            //     secondary_action: function () {
-            //       d.hide();
-            //     },
-            //   });
-            //   d.show();
-            // });
-          }
+        if (
+          frm.doc.status == "Pending" &&
+          frm.doc.stage_7_emp_status !== "Pending From Purchase"
+        ) {
+          // frm.add_custom_button(__("Pending From Purchase"), function () {
+          //   var d = new frappe.ui.Dialog({
+          //     title: __("Pending From Purchase Reason"),
+          //     fields: [
+          //       {
+          //         label: __(
+          //           "Please Give Reason of unavailability for this Asset Request"
+          //         ),
+          //         fieldname: "stage_7_emp_unavailable_reason",
+          //         fieldtype: "Small Text",
+          //         reqd: 1, // Set the unavailability reason field as mandatory
+          //       },
+          //     ],
+          //     primary_action_label: __("Submit"),
+          //     primary_action: function () {
+          //       // Check if the unavailability reason is provided
+          //       if (!d.fields_dict.stage_7_emp_unavailable_reason.get_value()) {
+          //         frappe.msgprint(
+          //           __("Please provide an unavailability reason.")
+          //         );
+          //         return;
+          //       }
+          //       // Generate a random 4-digit number
+          //       var randomOTP = Math.floor(1000 + Math.random() * 9000);
+          //       frm.set_value("stage_7_emp_status", "Pending From Purchase");
+          //       frm.set_value("store_otp", randomOTP); // Set the random number to store_otp
+          //       frm.set_value(
+          //         "stage_7_emp_unavailable_reason",
+          //         d.fields_dict.stage_7_emp_unavailable_reason.get_value()
+          //       );
+          //       d.hide();
+          //       frm.set_value("status", "Pending From Purchase");
+          //       console.log("Pending from Button");
+          //       frm.trigger("share_with_purchase");
+          //       cur_frm.save();
+          //     },
+          //     secondary_action_label: __("Cancel"),
+          //     secondary_action: function () {
+          //       d.hide();
+          //     },
+          //   });
+          //   d.show();
+          // });
         }
         // frappe.msgprint("RP Matched");
         frm.disable_save();

--- a/sahayog_asset/sahayog_asset/doctype/asset_request/asset_request.py
+++ b/sahayog_asset/sahayog_asset/doctype/asset_request/asset_request.py
@@ -249,81 +249,6 @@ def store_pending(doc):
 #     )
 #     return count[0][0] if count else 0
 
-
-@frappe.whitelist()
-def get_counts(employee_user):
-    statuses = [
-        "Pending",
-        "Dispatched",
-        "Received",
-        "Pending From Purchase",
-        "Pending From Store Manager",
-        "Rejected",
-        "Delivered",
-        "Draft",
-    ]
-    counts = {}
-
-    for status in statuses:
-        count = frappe.db.sql(
-            """SELECT COUNT(*)
-               FROM `tabAsset Request`
-               WHERE employee_user = %s
-               AND status = %s;""",
-            (employee_user, status),
-        )
-        counts[status.lower()] = count[0][0] if count else 0
-
-    return counts
-
-
-# for Reporting Manager
-@frappe.whitelist()
-def get_counts_request(employee_user):
-    statuses = ["Pending"]
-    counts = {}
-
-    for status in statuses:
-        count = frappe.db.sql(
-            """SELECT COUNT(*) AS count
-               FROM (
-                   SELECT ds.*, ar.status
-                   FROM `tabDocShare` ds
-                   JOIN `tabAsset Request` ar ON ds.share_name = ar.name
-                   WHERE ds.share_doctype = 'Asset Request'
-                   AND ds.user = %s
-                   AND ar.status = %s
-                   AND (
-                       (ar.stage_1_emp_status = 'Pending' AND ar.stage_1_emp_id = %s)
-                       OR
-                       (ar.stage_2_emp_status = 'Pending' AND ar.stage_2_emp_id = %s)
-                       OR
-                       (ar.stage_3_emp_status = 'Pending' AND ar.stage_3_emp_id = %s)
-                       OR
-                       (ar.stage_4_emp_status = 'Pending' AND ar.stage_4_emp_id = %s)
-                       OR
-                       (ar.stage_5_emp_status = 'Pending' AND ar.stage_5_emp_id = %s)
-                       OR
-                       (ar.stage_6_emp_status = 'Pending' AND ar.stage_6_emp_id = %s)
-                   )
-               ) AS subquery;""",
-            (
-                employee_user,
-                status,
-                employee_user,
-                employee_user,
-                employee_user,
-                employee_user,
-                employee_user,
-                employee_user,
-            ),
-        )
-        counts[status.lower()] = count[0][0] if count else 0
-
-    return counts
-
-
-# for Reporting Manager
 @frappe.whitelist()
 def get_approved_counts(employee_user):
     statuses = ["Pending"]
@@ -499,3 +424,156 @@ def get_all_count(employee_user):
         return True
     else:
         return False
+
+
+#permission query conditions and has_permission functions
+# These functions control access to the Asset Request doctype based on user roles and document properties.
+# They determine which records a user can see and whether they can perform actions on those records.
+def get_permission_query_conditions(user):
+    if not user:
+        return ""
+
+    roles = frappe.get_roles(user)
+
+    if user == "Administrator":
+        return ""  # Full access
+
+    if any(role in roles for role in [
+        "Admin Support Executive",
+        "Admin Support Manager",
+        "Admin Store Executive",
+        "Admin Store Manager"
+    ]):
+        return "`tabAsset Request`.`select_department` = 'Admin'"
+
+    if any(role in roles for role in [
+        "IT Support Executive",
+        "IT Store Executive",
+        "IT Store Manager"
+    ]):
+        return "`tabAsset Request`.`select_department` = 'IT'"
+
+    if "Stationery Store & Support Manager" in roles:
+        return "`tabAsset Request`.`select_department` = 'Stationery'"
+
+    # Default rule: show if user is employee_user OR in any stage_X_emp_id
+    return (
+        f"(`tabAsset Request`.`employee_user` = '{user}' "
+        f"OR `tabAsset Request`.`stage_1_emp_id` = '{user}' "
+        f"OR `tabAsset Request`.`stage_2_emp_id` = '{user}' "
+        f"OR `tabAsset Request`.`stage_3_emp_id` = '{user}' "
+        f"OR `tabAsset Request`.`stage_4_emp_id` = '{user}' "
+        f"OR `tabAsset Request`.`stage_5_emp_id` = '{user}' "
+        f"OR `tabAsset Request`.`stage_6_emp_id` = '{user}' "
+        f"OR `tabAsset Request`.`stage_7_emp_id` = '{user}')"
+    )
+
+def has_permission(doc, user):
+    roles = frappe.get_roles(user)
+
+    if user == "Administrator":
+        return True
+
+    if any(role in roles for role in [
+        "Admin Support Executive",
+        "Admin Support Manager",
+        "Admin Store Executive",
+        "Admin Store Manager"
+    ]):
+        return doc.select_department == "Admin"
+
+    if any(role in roles for role in [
+        "IT Support Executive",
+        "IT Store Executive",
+        "IT Store Manager"
+    ]):
+        return doc.select_department == "IT"
+
+    if "Stationery Store & Support Manager" in roles:
+        return doc.select_department == "Stationery"
+
+    # Allow if user is employee_user or any stage_X_emp_id
+    return (
+        doc.employee_user == user or
+        doc.stage_1_emp_id == user or
+        doc.stage_2_emp_id == user or
+        doc.stage_3_emp_id == user or
+        doc.stage_4_emp_id == user or
+        doc.stage_5_emp_id == user or
+        doc.stage_6_emp_id == user or
+        doc.stage_7_emp_id == user
+    )
+
+
+@frappe.whitelist()
+def get_counts(employee_user):
+    statuses = [
+        "Pending",
+        "Dispatched",
+        "Received",
+        "Pending From Purchase",
+        "Pending From Store Manager",
+        "Rejected",
+        "Delivered",
+        "Draft",
+    ]
+    counts = {}
+
+    for status in statuses:
+        count = frappe.db.sql(
+            """SELECT COUNT(*)
+               FROM `tabAsset Request`
+               WHERE employee_user = %s
+               AND status = %s;""",
+            (employee_user, status),
+        )
+        counts[status.lower()] = count[0][0] if count else 0
+
+    return counts
+
+
+# for Reporting Manager
+@frappe.whitelist()
+def get_counts_request(employee_user):
+    statuses = ["Pending"]
+    counts = {}
+
+    for status in statuses:
+        count = frappe.db.sql(
+            """SELECT COUNT(*) AS count
+               FROM (
+                   SELECT ds.*, ar.status
+                   FROM `tabDocShare` ds
+                   JOIN `tabAsset Request` ar ON ds.share_name = ar.name
+                   WHERE ds.share_doctype = 'Asset Request'
+                   AND ds.user = %s
+                   AND ar.status = %s
+                   AND (
+                       (ar.stage_1_emp_status = 'Pending' AND ar.stage_1_emp_id = %s)
+                       OR
+                       (ar.stage_2_emp_status = 'Pending' AND ar.stage_2_emp_id = %s)
+                       OR
+                       (ar.stage_3_emp_status = 'Pending' AND ar.stage_3_emp_id = %s)
+                       OR
+                       (ar.stage_4_emp_status = 'Pending' AND ar.stage_4_emp_id = %s)
+                       OR
+                       (ar.stage_5_emp_status = 'Pending' AND ar.stage_5_emp_id = %s)
+                       OR
+                       (ar.stage_6_emp_status = 'Pending' AND ar.stage_6_emp_id = %s)
+                   )
+               ) AS subquery;""",
+            (
+                employee_user,
+                status,
+                employee_user,
+                employee_user,
+                employee_user,
+                employee_user,
+                employee_user,
+                employee_user,
+            ),
+        )
+        counts[status.lower()] = count[0][0] if count else 0
+
+    return counts
+


### PR DESCRIPTION
- Allow Admin, IT, and Stationery roles to view based on select_department
- Allow stage_x_emp_id and employee_user to view their own requests
- Updated hooks.py to register permission functions