### PR TITLE
fix: use correct fields in check_user_divison_region query

### DIFF
--- a/sahayog_asset/sahayog_asset/doctype/purchase_requisition/division_region_api.py
+++ b/sahayog_asset/sahayog_asset/doctype/purchase_requisition/division_region_api.py
@@ -1,9 +1,10 @@
+
 import frappe
 
 
 @frappe.whitelist()
 def check_user_divison_region(emp_id):
     return frappe.db.sql(
-        f"""select division,region,department from `tabEmployee` where employee_id='{emp_id}';""",
+        f"""select custom_division,custom_region,department from `tabEmployee` where employee_number='{emp_id}';""",
         as_dict=True,
     )


### PR DESCRIPTION
Replaced raw 'division' reference with 'custom_division', 'custom_region', and 'department' to align with actual Employee doctype structure and prevent SQL errors.